### PR TITLE
integrated new Vercel AI SDK

### DIFF
--- a/clifscatalogv2/app/api/chat/route.tsx
+++ b/clifscatalogv2/app/api/chat/route.tsx
@@ -1,0 +1,27 @@
+import { OpenAIStream, StreamingTextResponse } from 'ai';
+import { Configuration, OpenAIApi } from 'openai-edge';
+
+// Create an OpenAI API client (that's edge friendly!)
+const config = new Configuration({
+  apiKey: process.env.OPENAI_API_KEY
+})
+const openai = new OpenAIApi(config);
+
+// IMPORTANT! Set the runtime to edge
+export const runtime = 'edge';
+ 
+export async function POST(req: Request) {
+  // Extract the `messages` from the body of the request
+  const { messages } = await req.json();
+ 
+  // Ask OpenAI for a streaming chat completion given the prompt
+  const response = await openai.createChatCompletion({
+    model: 'gpt-3.5-turbo',
+    stream: true,
+    messages
+  });
+  // Convert the response into a friendly text-stream
+  const stream = OpenAIStream(response);
+  // Respond with the stream
+  return new StreamingTextResponse(stream);
+}

--- a/clifscatalogv2/app/components/HeroSection.tsx
+++ b/clifscatalogv2/app/components/HeroSection.tsx
@@ -1,10 +1,11 @@
+import Chat from "../functional_components/Chat";
 import "../globalStyles.css";
 import HeroSectionStyles from "../modular_css/HeroSection.module.css";
 
 export const HeroSection = () => {
   return (
     <main className={HeroSectionStyles.container}>
-
+      <Chat />
     </main>    
   );
 };

--- a/clifscatalogv2/app/components/Navigation.tsx
+++ b/clifscatalogv2/app/components/Navigation.tsx
@@ -21,7 +21,7 @@ export const Navigation = () => {
             </div>
             <ul>
                 <li>Pick For Me</li>
-                <li>My Sous-chef vercel ai</li>
+                <li>My Sous-chef</li>
                 <li>My favorites</li>
                 <li>Something Here</li>
                 <li>Sign Up/In</li>

--- a/clifscatalogv2/app/functional_components/Chat.tsx
+++ b/clifscatalogv2/app/functional_components/Chat.tsx
@@ -1,0 +1,28 @@
+'use client'
+import '../globalStyles.css';
+import ChatStyles from '../modular_css/Chat.module.css';
+import { useChat } from 'ai/react'
+
+export default function Chat() {
+  const { messages, input, handleInputChange, handleSubmit } = useChat()
+
+  return (
+    <div>
+      {messages.map(message => (
+        <div key={message.id}>
+          {message.role}: {message.content}
+        </div>
+      ))}
+
+      <form onSubmit={handleSubmit} className={ChatStyles.form}>
+        <label>
+          Say something...
+          <input
+            value={input}
+            onChange={handleInputChange}
+          />
+        </label>
+      </form>
+    </div>
+  )
+}

--- a/clifscatalogv2/package.json
+++ b/clifscatalogv2/package.json
@@ -15,6 +15,7 @@
     "eslint": "8.44.0",
     "eslint-config-next": "13.4.8",
     "next": "13.4.8",
+    "openai-edge": "^1.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.1.6"


### PR DESCRIPTION
This pull request handles issue #1 : Implement Vercel AI SDK into meal app. Styling has not been handled yet, as I will be creating separate PR's for styling needs down the road. 

Future functionality : add a <Link> element for the Vercel SDK for the "My Sous-chef" option on the Navbar. This page will be an AI assistant that you can ask questions to: I.E., I feel like eating something salty and sweet, but I can't think of anything. Do you have any suggestions?

There will also be functionality to store the suggestion from chatGPT to user favorite queries down the road. 

Expected : The assistant should be able to suggest meals to users, and link them directly to the recipe on the site if they should please. 